### PR TITLE
use a Makefile to ease getting up and running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all:
+	mvn -Dmaven.test.skip=true clean install
+	mvn -f core-webapp/pom.xml spring-boot:run
+
+es:
+	docker run -d elasticsearch:2.4.4
+
+


### PR DESCRIPTION
While the maven commands are simple to use, they are hard to remember
IMO. Running just `make` is nicer and shorter. The Makefile could be
used to capture tedious repetitive tasks.  For now I have just added two
recipes the default target `make` will try to build and run. `make es`
should spin up a elasticsearch container.