### PR TITLE
add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:8
+
+# Environment variables
+ENV APP_ROOT "/srv/nikita-noark5-core"
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get install -y maven git
+
+# Clone source and change the working directory
+RUN git clone https://github.com/HiOA-ABI/nikita-noark5-core.git $APP_ROOT
+WORKDIR $APP_ROOT
+
+# Get the application running
+RUN mvn -Dmaven.test.skip=true clean install
+RUN mvn -f core-webapp/pom.xml spring-boot:run
+
+EXPOSE 8092 8082

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# docker build says: reference format: repository name must be lowercase
+project ?=hioa-abi/nikita-noark5-core
+
 all: run
 
 build:
@@ -6,6 +9,13 @@ run: build
 	mvn -f core-webapp/pom.xml spring-boot:run
 
 es:
-	docker run -d elasticsearch:2.4.4
-
-
+	docker run -d --name=elasticsearch elasticsearch:2.4.4
+docker:
+	docker build -t ${project} .
+docker_deploy: docker docker_push
+	echo "Pushed to docker"
+docker_run: docker
+	docker start elasticsearch
+	docker run -dit --link elasticsearch ${project}
+docker_push:
+	docker push ${project}


### PR DESCRIPTION
By using docker[0] we can make it very easy for someone who is interested in
spinning up a new instance to get started. Instead of installing all of the
dependencies and going through the hassle of having the right versions,
requiring only one command like `make docker_run` is a much better experience.

For now the container is cloning the source so it's less focused on using the
local files. This can be changed if there is a strong need for making it easier
to test the local changes, but it would require some more thought.

Some changes were made to the Makefile. The name field is now being set for the
elasticsearch container which makes it easier to use with other containers via
the `--link` option and we have four more targets[1] to the Makefile. The
targets are there primarily so people are not required to remember the options
but can just rely on using `make docker_X` to trigger the actions.

[0]: https://www.docker.com/
[1]:
- `make docker` - Builds the container.
- `make docker_deploy` - Builds the container and uploads it to hub.docker.com.
- `make docker_run` - Builds and then runs the container.
- `make docker_push` - Uploads a built container to hub.docker.com.
Note that uploading to docker hub might require having a account.

This is a work in progress.