### PR TITLE
Fix connection issues when using `make es` and `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,15 @@ build:
 run: build
 	mvn -f core-webapp/pom.xml spring-boot:run
 
+# This target is only expected to be run once.  If you have created the
+# container but it's not running use `docker start elasticsearch` instead of
+# rerunning this target.
 es:
-	docker run -d --name=elasticsearch elasticsearch:2.4.4
+	docker run -d --name=elasticsearch -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
+	# It might take some seconds to get up the elasticsearch container
+	sleep 10
+	curl http://localhost:9200
+	curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
 docker:
 	docker build -t ${project} .
 docker_deploy: docker docker_push


### PR DESCRIPTION
While it add comments and handle known issues when using elasticsearch.  This
should also address some hibernate boot exceptions.

Reference:
o https://github.com/docker-library/elasticsearch/issues/58
o https://github.com/HiOA-ABI/nikita-noark5-core/blob/master/0.2-release/elasticsearch.txt