### PR TITLE
Makefile: add new target to use noark5-tester[0]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # docker build says: reference format: repository name must be lowercase
 project ?=hioa-abi/nikita-noark5-core
+repo_tester_dir ?=../noark5-tester
+repo_tester ?=https://github.com/petterreinholdtsen/noark5-tester
 
 all: run
 
@@ -7,6 +9,15 @@ build:
 	mvn -Dmaven.test.skip=true clean install
 run: build
 	mvn -f core-webapp/pom.xml spring-boot:run
+
+# This target should be run after spinning up elasticsearch and the application.
+# The tester might have more dependencies but you should at least have installed
+# python-mechanize.
+tt:
+	if ! test -d $(repo_tester_dir); then \
+	  git clone $(repo_tester) $(repo_tester_dir); \
+	fi
+	cd $(repo_tester_dir) && ./runtest --reference
 
 # This target is only expected to be run once.  If you have created the
 # container but it's not running use `docker start elasticsearch` instead of


### PR DESCRIPTION
The repo_* variables have default values but could be changed out.  In
order to make it more user friendly the repository is cloned if it
doesn't exist.

References:

https://github.com/petterreinholdtsen/noark5-tester/issues/1#issuecomment-281139379
[0]: https://github.com/petterreinholdtsen/noark5-tester