### PR TITLE
Makefile: package target should depend on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,5 @@ docker_push:
 docker_tail:
 	docker logs `docker ps | grep ${project} | awk ' { print $$1 } '`
 # Prepare a package which can be used to deploy the application
-package:
+package: build
 	mvn -Dmaven.test.skip=true package spring-boot:repackage


### PR DESCRIPTION
This fixes a compile errors which only shows up after cleaning the
project and then attempting packaging it.