### PR TITLE
Add support for Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ local.properties
 
 # Code Recommenders
 .recommenders/
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "debian/testing64"
+  config.vm.provision :shell, path: "install-deps-debian.sh"
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+        apt-get install -y curl make
+        curl -sSL https://get.docker.com/ | sh
+        adduser vagrant docker
+	make -C /vagrant es
+        su - vagrant -c "make -C /vagrant build"
+  SHELL
+end

--- a/install-deps-debian.sh
+++ b/install-deps-debian.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+apt-get update
+apt-get install -y maven openjdk-8-jdk python-mechanize


### PR DESCRIPTION
Vagrant[0] makes it easier to create a reproducible environment and can
potentially help new people to get a environment up and running by. This
setup uses the upsteam version of docker and it also adds the vagrant
user to the docker group while not required but for debug nice to have
access to docker. The vm should have everything you need including
elasticsearch and various dependencies required to run the application.

Using this should look something like:
```shell
  vagrant up
  vagrant ssh
  cd /vagrant && make run
```
Later when you have changes:
```shell
  vagrant reload
```

This is also something we could use with some continuous integration.
Not sure about travis, but Jenkins has a plugin[1] which might be
useful.

Please note that docker is not included in install-deps-debian.sh so
that the script is still useful for non docker users.

[0]: https://www.vagrantup.com/
[1]: https://wiki.jenkins-ci.org/display/JENKINS/Vagrant-plugin