### PR TITLE
Add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+    - oraclejdk8


### PR DESCRIPTION
The tests don't work yet, but when they do having a continuous
integration setup ready to run them will be good. Instead of waiting
let's start using travis[0].

The other nice stuff like a badge to the README and / or pull request
integration can be added later.

[0]: https://travis-ci.org