### PR TITLE
Fix mapping error when using jar file with Thymeleaf

### DIFF
--- a/core-webapp/src/main/java/no/arkivlab/hioa/nikita/webapp/spring/AppWebMvcConfiguration.java
+++ b/core-webapp/src/main/java/no/arkivlab/hioa/nikita/webapp/spring/AppWebMvcConfiguration.java
@@ -58,9 +58,9 @@ public class AppWebMvcConfiguration extends WebMvcConfigurerAdapter {
      */
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
-        registry.addViewController("/login").setViewName("/webapp/login/loginPage");
-        registry.addViewController("/fonds").setViewName("/webapp/noark/fonds/list");
-        registry.addViewController("/gui").setViewName("/webapp/login/loginPage");
+        registry.addViewController("/login").setViewName("webapp/login/loginPage");
+        registry.addViewController("/fonds").setViewName("webapp/noark/fonds/list");
+        registry.addViewController("/gui").setViewName("webapp/login/loginPage");
 
         registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
     }


### PR DESCRIPTION
Turns out the IDE is doing some magic in the background and strips away
preceded slashes. This is not the case for the jar and we get the mapping
errors below.

2017-02-23 23:24:56.491 ERROR 1 --- [0.1-8092-exec-5] org.thymeleaf.TemplateEngine             : [THYMELEAF][http-nio-127.0.0.1-8092-exec-5] Exception processing template "/webapp/login/loginPage": Error resolving template "/webapp/login/loginPage", template might not exist or migh
t not be accessible by any of the configured Template Resolvers
2017-02-23 23:24:56.492 ERROR 1 --- [0.1-8092-exec-5] o.a.c.c.C.[.[.[.[dispatcherServlet]      : Servlet.service() for servlet [dispatcherServlet] in context with path [/noark5v4] threw exception [Request processing failed; nested exception is org.thymeleaf.exceptions.TemplateInput
Exception: Error resolving template "/webapp/login/loginPage", template might not exist or might not be accessible by any of the configured Template Resolvers] with root cause

Reference:
https://github.com/spring-projects/spring-boot/issues/2057
https://github.com/spring-projects/spring-boot/issues/1744