### PR TITLE
Makefile: let docker_run depend on build and package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ es:
 	curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
 docker:
 	docker build -t ${project} .
-docker_deploy: docker docker_push
+docker_deploy: build package docker docker_push
 	echo "Pushed to docker, https://hub.docker.com/r/${project}"
 docker_run: build package docker
 	docker start elasticsearch


### PR DESCRIPTION
This let's you run deploy on a empty build so you have the jar needed by the
builder.  Fixes the following issue:

docker build -t nikita5/nikita-noark5-core .
Sending build context to Docker daemon 138.1 MB
Step 1/6 : FROM java:8
 ---> d23bdf5b1b1b
Step 2/6 : VOLUME /tmp
 ---> Using cache
 ---> ccf7b0663c61
Step 3/6 : ADD core-webapp/target/core-webapp-0.1.0-spring-boot.jar app.jar
lstat core-webapp/target/core-webapp-0.1.0-spring-boot.jar: no such file or director