### PR TITLE
Install: remove build line for docker setup

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -61,7 +61,6 @@ exceptions. (Please let us know if there are any exceptions).
 
 ## Docker
 
-    docker build -t nikita5/nikita-noark5-core .
     docker run -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
     docker run --network=host -dit nikita5/nikita-noark5-core
 


### PR DESCRIPTION
While nice to build it is already covered by the Makefile, the two
remaining commands is the minimum required to spin up the application.