### PR TITLE
Makefile: add moby host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docker_deploy: build package docker docker_push
 	echo "Pushed to docker, https://hub.docker.com/r/${project}"
 docker_run: build package docker
 	docker start elasticsearch
-	docker run --network="host" -dit ${project}
+	docker run --network="host" --add-host=moby:127.0.0.1 -dit ${project}
 docker_push:
 	docker push ${project}
 docker_tail:


### PR DESCRIPTION
Fixes the following error:

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'startDBManager' defined in
                 no.arkivlab.hioa.nikita.webapp.spring.datasource.DemoDataSource: Bean instantiation via factory method failed; nested exception is
                 org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.h2.tools.Server]: Factory method 'startDBManager' threw exception; nested
exception is org.h2.jdbc.JdbcSQLException: IO Exception: "java.net.UnknownHostException: moby: moby: Name or service not known" [90028-190]

Reference:
http://blog.yohanliyanage.com/2016/09/docker-machine-moby-name-or-service-not-known/