### PR TITLE
Makefile: Install: use variable host

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -62,7 +62,7 @@ exceptions. (Please let us know if there are any exceptions).
 ## Docker
 
     docker run -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
-    docker run --network=host -dit nikita5/nikita-noark5-core
+    docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
 
 ## Vagrant
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docker_deploy: build package docker docker_push
 	echo "Pushed to docker, https://hub.docker.com/r/${project}"
 docker_run: build package docker
 	docker start elasticsearch
-	docker run --network="host" --add-host=moby:127.0.0.1 ${project}
+	docker run --network="host" --add-host=$(shell hostname):127.0.0.1 ${project}
 docker_push:
 	docker push ${project}
 docker_tail:


### PR DESCRIPTION
The previous moby fix will only work on a docker machine for macOS.
Using the hostname is more reliable.