### PR TITLE
Makefile: Add docker compose target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ docker_push:
 	docker push ${project}
 docker_tail:
 	docker logs `docker ps | grep ${project} | awk ' { print $$1 } '`
+docker_compose:
+	docker-compose up
 # Prepare a package which can be used to deploy the application
 package: build
 	mvn -Dmaven.test.skip=true package spring-boot:repackage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  elasticsearch:
+    image: "elasticsearch:2.4.4"
+    ports:
+     - "9200:9200"
+  nikita-noark5-core:
+    image: "nikita5/nikita-noark5-core"
+    ports:
+     - "8092:8092"
+     - "8082:8082"


### PR DESCRIPTION
Compose[0] let's us define and run multiple containers with docker.

```bash
root@ip-172-31-21-156:/home/ubuntu/src/nikita-noark5-core# docker-compose up # or make docker_compose
Creating network "nikitanoark5core_default" with the default driver
Pulling elasticsearch (elasticsearch:2.4.4)...
2.4.4: Pulling from library/elasticsearch
5040bd298390: Pull complete
fce5728aad85: Pull complete
c42794440453: Pull complete
0c0da797ba48: Pull complete
7c9b17433752: Pull complete
d4d33418bd6d: Pull complete
0e10cce36e52: Pull complete
09dd4de551b0: Pull complete
dd2fffb2567d: Pull complete
00600327a779: Pull complete
fae2df12d2f6: Pull complete
f60afcfaf7ae: Pull complete
7054ec74e0a2: Pull complete
4c5d3a9e8b2a: Pull complete
Digest: sha256:c977957d91c253eff6ea19f0501a2b2ae39a06e8e10d9adf5404a9fd62579682
Status: Downloaded newer image for elasticsearch:2.4.4
Pulling nikita-noark5-core (nikita5/nikita-noark5-core:latest)...
latest: Pulling from nikita5/nikita-noark5-core
5040bd298390: Already exists
fce5728aad85: Already exists
76610ec20bf5: Pull complete
60170fec2151: Pull complete
e98f73de8f0d: Pull complete
11f7af24ed9c: Pull complete
49e2d6393f32: Pull complete
bb9cdec9c7f3: Pull complete
012381f14275: Pull complete
8351346773cc: Pull complete
Digest: sha256:ceab61427cea95a75102077ae743efb973a9aa8c9856b9684583d1670d8ecf1d
Status: Downloaded newer image for nikita5/nikita-noark5-core:latest
Creating nikitanoark5core_nikita-noark5-core_1
Creating nikitanoark5core_elasticsearch_1
Attaching to nikitanoark5core_nikita-noark5-core_1, nikitanoark5core_elasticsearch_1
```

[0]: https://github.com/docker/compose