### PR TITLE
Dockerfile: use github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
 FROM java:8
 VOLUME /tmp
 
-ADD core-webapp/target/core-webapp-0.1.0-spring-boot.jar app.jar
+ENV REPO "https://github.com/HiOA-ABI/nikita-noark5-core"
+ENV SRC_DIR "/srv/nikita-noark5-core"
+ENV BRANCH "master"
+
+RUN apt-get update
+RUN apt-get install -y git make maven
+RUN git clone $REPO  $SRC_DIR
+RUN git -C $SRC_DIR checkout $BRANCH
+RUN make -C $SRC_DIR package
+RUN cp $SRC_DIR/core-webapp/target/core-webapp-0.1.0-spring-boot.jar app.jar
+
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN bash -c 'touch /app.jar'
 
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
This makes the container buildable from docker hub. We do lose the
option to test local wars, but pushing your branch to github and
changing the environment's should not be that hard.

Also tried to slim down apt cache.