### PR TITLE
Install: make the Docker section more copy / paste friendly

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -62,6 +62,8 @@ exceptions. (Please let us know if there are any exceptions).
 ## Docker
 
     docker run -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
+    curl http://localhost:9200
+    curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
     docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
 
 ## Vagrant


### PR DESCRIPTION
In order to make avoid the HSEARCH400024 which is already documented.
We need to figure out how to fix this for the docker-compose...