### PR TITLE
Revert "Makefile: let docker_run depend on build and package target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ es:
 	curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
 docker:
 	docker build -t ${project} .
-docker_deploy: build package docker docker_push
+docker_deploy: docker docker_push
 	echo "Pushed to docker, https://hub.docker.com/r/${project}"
-docker_run: build package docker
+docker_run: docker
 	docker start elasticsearch
 	docker run --network="host" --add-host=$(shell hostname):127.0.0.1 ${project}
 docker_push:


### PR DESCRIPTION
This commit was needed earlier but because we changed the way the Docker
container is being built this is no longer needed and is only incurring
unnecessary build time.

This reverts commit 6e5fdfa38936ee82d2657dc0d78e0e08768c9316.