### PR TITLE
docs: add noark5-tester container run to Install

### DIFF
--- a/docs/general/Install.md
+++ b/docs/general/Install.md
@@ -65,6 +65,7 @@ exceptions. (Please let us know if there are any exceptions).
     curl http://localhost:9200
     curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
     docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
+    docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/noark5-tester
 
 ## Vagrant
 


### PR DESCRIPTION
While not essential there, is nice to be able to copy
all the lines and just run them.