### PR TITLE
web/README: fix port typo

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -5,6 +5,6 @@ A angular application for interacting with [nikita-noark5-core][n].
 You can start the application by running
 
     make run
-    # Should be running at http://localhost:4200/
+    # Should be running at http://localhost:3000/
 
 [n]: https://github.com/HiOA-ABI/nikita-noark5-core


### PR DESCRIPTION
When re basing earlier, I must have missed that the port should be 3000
not 4200 from angular-cli.