### PR TITLE
scripts: docs: use a separate script for spinning up containers

### DIFF
--- a/docs/general/Install.md
+++ b/docs/general/Install.md
@@ -61,11 +61,10 @@ exceptions. (Please let us know if there are any exceptions).
 
 ## Docker
 
-    docker run -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
-    curl http://localhost:9200
-    curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
-    docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
-    docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/noark5-tester
+There are several containers required to get the application up, you can start them all
+with the script below
+
+    scripts/start-containers
 
 ## Vagrant
 

--- a/scripts/start-containers
+++ b/scripts/start-containers
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function wait_on_x()
+{
+  echo "Waiting on $1"
+  sleep $2
+}
+
+echo "This might take some minutes, sit back and relax with a beverage"
+
+# Stop the running containers
+docker stop elasticsearch server tester
+
+# Remove them
+docker rm elasticsearch server tester
+
+# Pull in latest version
+docker pull elasticsearch:2.4.4
+docker pull nikita5/noark5-tester
+docker pull nikita5/nikita-noark5-core
+
+# Get elasticsearch up
+docker run --name=elasticsearch -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
+wait_on_x elasticsearch 10
+curl http://localhost:9200
+curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
+
+# Get the main application up
+docker run --name=server -d --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
+wait_on_x server 45
+
+# Run test
+docker run --name=tester --network="host" --add-host=`hostname`:127.0.0.1 nikita5/noark5-tester
+
+# TODO: add web container when ready


### PR DESCRIPTION
Instead of duplicating lines just use the script the install
instructions as well. This script can be used to setup staging server
for prototyping.