### PR TITLE
Makefile: add vagrant target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ package: build
 	mvn -Dmaven.test.skip=true package spring-boot:repackage
 stop-containers:
 	docker stop server web elasticsearch
+vagrant:
+	vagrant box update
+	vagrant up

--- a/docs/general/Install.md
+++ b/docs/general/Install.md
@@ -68,6 +68,6 @@ with the script below
 
 ## Vagrant
 
-    vagrant up
+    make vagrant
     vagrant ssh
     cd /vagrant && make run


### PR DESCRIPTION
Experienced the error below, letting vagrant update the
box first fixes the issue.

    ...
    The following SSH command responded with a non-zero exit status.
    Vagrant assumes that this means the command failed!

    apt-get -y update
    ...