### PR TITLE
use hioaabi for nikita-noark5-core image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # docker build says: reference format: repository name must be lowercase
-project ?=nikita5/nikita-noark5-core
+project ?=hioaabi/nikita-noark5-core
 repo_tester_dir ?=../noark5-tester
 repo_tester ?=https://github.com/petterreinholdtsen/noark5-tester
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
      - "9200:9200"
   nikita-noark5-core:
-    image: "nikita5/nikita-noark5-core"
+    image: "hioaabi/nikita-noark5-core"
     ports:
      - "8092:8092"
      - "8082:8082"

--- a/scripts/start-containers
+++ b/scripts/start-containers
@@ -17,7 +17,7 @@ docker rm elasticsearch server tester web
 # Pull in latest version
 docker pull elasticsearch:2.4.4
 docker pull nikita5/noark5-tester
-docker pull nikita5/nikita-noark5-core
+docker pull hioaabi/nikita-noark5-core
 docker pull nikita5/web
 
 # Get elasticsearch up
@@ -28,9 +28,9 @@ curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*",
 
 # Get the main application up
 if [[ `uname` == "Darwin" ]]; then
-  docker run --name=server -d --network="host" --add-host=moby:127.0.0.1 nikita5/nikita-noark5-core
+  docker run --name=server -d --network="host" --add-host=moby:127.0.0.1 hioaabi/nikita-noark5-core
 else
-  docker run --name=server -d --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
+  docker run --name=server -d --network="host" --add-host=`hostname`:127.0.0.1 hioaabi/nikita-noark5-core
 fi
 wait_on_x server 45
 


### PR DESCRIPTION
I created new organization[0] which is connected to the Github repository.
While there is nothing wrong with using nikita5 it is incurring extra work on my
part to make sure the nikita5 fork is up to date. By using autobuild on the main
repository we can get latest changes sooner instead of waiting for me to
manually refresh my fork in order to trigger a rebuild.

[0]: https://hub.docker.com/r/hioaabi/nikita-noark5-core/