### PR TITLE
web/Makefile: add targets for Debian users

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -5,8 +5,24 @@ instance_name=nikita_web
 setup:
 	npm install
 	npm install nodemon
+
+setup-debian:
+	apt-get install -y libjs-angularjs node-express node-body-parser wget
+	mkdir -pv node_modules
+	ln -s /usr/share/javascript/angular.js node_modules/angular
+	ln -s /usr/lib/nodejs/express/ node_modules/express
+	ln -s /usr/lib/nodejs/body-parser node_modules/body-parser
+	# getmdl is not packaged for debian
+	mkdir -pv node_modules/material-design-lite
+	cd node_modules/material-design-lite
+	wget https://code.getmdl.io/1.3.0/material.min.css
+	wget https://code.getmdl.io/1.3.0/material.min.js
+
+
 run:
 	DEBUG=web:* npm start
+run-debian:
+	nodejs server.js
 # This target will restart server on changes.
 tt:
 	nodemon server.js


### PR DESCRIPTION
The target should help Debian people avoid using npm, and maybe ease
potential future packaging efforts. Unfortunately getmdl does not have
Debian package (based on some minutes of searching). So therefore we
just download the files needed for now.