### PR TITLE
build: use dedicated script for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 
 script:
-- ./scripts/start-containers
+- ./scripts/run-all-tests

--- a/scripts/run-all-tests
+++ b/scripts/run-all-tests
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# TODO: replace start containers with manually building
+time scripts/start-containers
+
+# Add new test scripts below and please time it.


### PR DESCRIPTION
Just starting the containers is not enough and using a separate
script let's us extend the runner with more tests in the future.

Also added todo for replacing the call to start-containers with
actually building the container so we test local changes not just
latest changes.