### PR TITLE
build: let travis build the new container from local changes

### DIFF
--- a/scripts/ci-test-runner
+++ b/scripts/ci-test-runner
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+project=hioaabi/nikita-noark5-core
+
+# In order to also run this locally clean up containers to prevent name collisions.
+docker stop elasticsearch server tester
+docker rm elasticsearch server tester
+
+# Get elasticsearch up
+docker run --name=elasticsearch -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
+sleep 10
+curl http://localhost:9200
+curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
+
+# Build local container and start it.
+docker build -t $project .
+docker run --name=server -d --network="host" --add-host=`hostname`:127.0.0.1 $project
+sleep 45
+
+# Run test
+docker run --name=tester --network="host" --add-host=`hostname`:127.0.0.1 nikita5/noark5-tester

--- a/scripts/run-all-tests
+++ b/scripts/run-all-tests
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# TODO: replace start containers with manually building
-time scripts/start-containers
+time scripts/ci-test-runner
 
 # Add new test scripts below and please time it.


### PR DESCRIPTION
As mentioned in b13561665a38 (build: use dedicated script for running
tests, 2017-03-31) we are not doing a realistic test of the pull
requests. This patch fixes that by building the image and running it.