### PR TITLE
build: send notifications when done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ services:
 
 script:
 - ./scripts/run-all-tests
+
+notifications:
+  irc: "chat.freenode.net#nikita"


### PR DESCRIPTION
The IRC channel is becoming a center of communication for the project, send the
build notifications there so users don't need to check Github for latest status.