### PR TITLE
Correct relation names for electronic signatures.

### DIFF
--- a/core-common/src/main/java/nikita/config/N5ResourceMappings.java
+++ b/core-common/src/main/java/nikita/config/N5ResourceMappings.java
@@ -207,9 +207,9 @@ public final class N5ResourceMappings {
     public static final String CROSS_REFERENCE_CLASS = "referanseTilKlasse";
 
     // ElectronicSignature
-    public static final String ELECTRONIC_SIGNATURE = "elektroniskSignatur";
-    public static final String ELECTRONIC_SIGNATURE_SECURITY_LEVEL = "elektroniskSignaturSikkerhetsnivaa";
-    public static final String ELECTRONIC_SIGNATURE_VERIFIED = "elektroniskSignaturVerifisert";
+    public static final String ELECTRONIC_SIGNATURE = "elektronisksignatur";
+    public static final String ELECTRONIC_SIGNATURE_SECURITY_LEVEL = "elektronisksignatursikkerhetsnivaa";
+    public static final String ELECTRONIC_SIGNATURE_VERIFIED = "elektronisksignaturverifisert";
     public static final String ELECTRONIC_SIGNATURE_VERIFIED_DATE = "verifisertDato";
     public static final String ELECTRONIC_SIGNATURE_VERIFIED_BY = "verifisertAv";
 

--- a/core-common/src/main/java/nikita/model/noark5/v4/ElectronicSignature.java
+++ b/core-common/src/main/java/nikita/model/noark5/v4/ElectronicSignature.java
@@ -23,14 +23,14 @@ public class ElectronicSignature implements Serializable {
     protected Long id;
 
     /**
-     * M507 - elektroniskSignaturSikkerhetsnivaa (xs:string)
+     * M507 - elektronisksignatursikkerhetsnivaa (xs:string)
      */
     @Column(name = "electronic_signature_security_level")
     @Audited
     protected String electronicSignatureSecurityLevel;
 
     /**
-     * M508 - elektroniskSignaturVerifisert (xs:string)
+     * M508 - elektronisksignaturverifisert (xs:string)
      */
     @Column(name = "electronic_sSignature_verified")
     @Audited


### PR DESCRIPTION
Make sure the relation names match the specification:
 - elektroniskSignatur -> elektronisksignatur
 - elektroniskSignaturSikkerhetsnivaa -> elektronisksignatursikkerhetsnivaa
 - elektroniskSignaturVerifisert -> elektronisksignaturverifisert